### PR TITLE
Use `tempdir` Over Custom Directory Setup and Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,8 +18,24 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 name = "database-engine"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "tempfile",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
@@ -34,31 +56,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
+name = "linux-raw-sys"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "once_cell"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
-dependencies = [
- "proc-macro2",
-]
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "r-efi"
@@ -67,50 +74,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.9.2"
+name = "rustix"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
+name = "tempfile"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
+ "fastrand",
  "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
-
-[[package]]
-name = "syn"
-version = "2.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wasip2"
@@ -122,27 +109,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-rand = "0.9.2"
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -126,13 +126,11 @@ impl IntoIterator for WAL {
 #[cfg(test)]
 mod tests {
   use crate::wal::WAL;
-  use rand::prelude::*;
-  use std::fs::{create_dir, remove_dir_all};
   use std::fs::{metadata, File, OpenOptions};
   use std::io::prelude::*;
   use std::io::BufReader;
-  use std::path::PathBuf;
   use std::time::{SystemTime, UNIX_EPOCH};
+  use tempfile::tempdir;
 
   fn check_entry(
     reader: &mut BufReader<File>,
@@ -175,16 +173,14 @@ mod tests {
 
   #[test]
   fn test_write_one() {
-    let mut rng = rand::rng();
-    let dir = PathBuf::from(format!("./{}/", rng.random::<u32>()));
-    create_dir(&dir).unwrap();
+    let dir = tempdir().unwrap();
 
     let timestamp = SystemTime::now()
       .duration_since(UNIX_EPOCH)
       .unwrap()
       .as_micros();
 
-    let mut wal = WAL::new(&dir).unwrap();
+    let mut wal = WAL::new(dir.path()).unwrap();
     wal.set(b"Lime", b"Lime Smoothie", timestamp).unwrap();
     wal.flush().unwrap();
 
@@ -198,15 +194,11 @@ mod tests {
       timestamp,
       false,
     );
-
-    remove_dir_all(&dir).unwrap();
   }
 
   #[test]
   fn test_write_many() {
-    let mut rng = rand::rng();
-    let dir = PathBuf::from(format!("./{}/", rng.random::<u32>()));
-    create_dir(&dir).unwrap();
+    let dir = tempdir().unwrap();
 
     let timestamp = SystemTime::now()
       .duration_since(UNIX_EPOCH)
@@ -219,7 +211,7 @@ mod tests {
       (b"Orange", Some(b"Orange Smoothie")),
     ];
 
-    let mut wal = WAL::new(&dir).unwrap();
+    let mut wal = WAL::new(dir.path()).unwrap();
 
     for e in entries.iter() {
       wal.set(e.0, e.1.unwrap(), timestamp).unwrap();
@@ -232,15 +224,11 @@ mod tests {
     for e in entries.iter() {
       check_entry(&mut reader, e.0, e.1, timestamp, false);
     }
-
-    remove_dir_all(&dir).unwrap();
   }
 
   #[test]
   fn test_write_delete() {
-    let mut rng = rand::rng();
-    let dir = PathBuf::from(format!("./{}/", rng.random::<u32>()));
-    create_dir(&dir).unwrap();
+    let dir = tempdir().unwrap();
 
     let timestamp = SystemTime::now()
       .duration_since(UNIX_EPOCH)
@@ -253,7 +241,7 @@ mod tests {
       (b"Orange", Some(b"Orange Smoothie")),
     ];
 
-    let mut wal = WAL::new(&dir).unwrap();
+    let mut wal = WAL::new(dir.path()).unwrap();
 
     for e in entries.iter() {
       wal.set(e.0, e.1.unwrap(), timestamp).unwrap();
@@ -273,30 +261,22 @@ mod tests {
     for e in entries.iter() {
       check_entry(&mut reader, e.0, None, timestamp, true);
     }
-
-    remove_dir_all(&dir).unwrap();
   }
 
   #[test]
   fn test_read_wal_none() {
-    let mut rng = rand::rng();
-    let dir = PathBuf::from(format!("./{}/", rng.random::<u32>()));
-    create_dir(&dir).unwrap();
+    let dir = tempdir().unwrap();
 
-    let (new_wal, new_mem_table) = WAL::load_from_dir(&dir).unwrap();
+    let (new_wal, new_mem_table) = WAL::load_from_dir(dir.path()).unwrap();
     assert_eq!(new_mem_table.len(), 0);
 
     let m = metadata(new_wal.path).unwrap();
     assert_eq!(m.len(), 0);
-
-    remove_dir_all(&dir).unwrap();
   }
 
   #[test]
   fn test_read_wal_one() {
-    let mut rng = rand::rng();
-    let dir = PathBuf::from(format!("./{}/", rng.random::<u32>()));
-    create_dir(&dir).unwrap();
+    let dir = tempdir().unwrap();
 
     let entries: Vec<(&[u8], Option<&[u8]>)> = vec![
       (b"Apple", Some(b"Apple Smoothie")),
@@ -304,14 +284,14 @@ mod tests {
       (b"Orange", Some(b"Orange Smoothie")),
     ];
 
-    let mut wal = WAL::new(&dir).unwrap();
+    let mut wal = WAL::new(dir.path()).unwrap();
 
     for (i, e) in entries.iter().enumerate() {
       wal.set(e.0, e.1.unwrap(), i as u128).unwrap();
     }
     wal.flush().unwrap();
 
-    let (new_wal, new_mem_table) = WAL::load_from_dir(&dir).unwrap();
+    let (new_wal, new_mem_table) = WAL::load_from_dir(dir.path()).unwrap();
 
     let file = OpenOptions::new().read(true).open(&new_wal.path).unwrap();
     let mut reader = BufReader::new(file);
@@ -324,22 +304,18 @@ mod tests {
       assert_eq!(mem_e.value.as_ref().unwrap().as_slice(), e.1.unwrap());
       assert_eq!(mem_e.timestamp, i as u128);
     }
-
-    remove_dir_all(&dir).unwrap();
   }
 
   #[test]
   fn test_read_wal_multiple() {
-    let mut rng = rand::rng();
-    let dir = PathBuf::from(format!("./{}/", rng.random::<u32>()));
-    create_dir(&dir).unwrap();
+    let dir = tempdir().unwrap();
 
     let entries_1: Vec<(&[u8], Option<&[u8]>)> = vec![
       (b"Apple", Some(b"Apple Smoothie")),
       (b"Lime", Some(b"Lime Smoothie")),
       (b"Orange", Some(b"Orange Smoothie")),
     ];
-    let mut wal_1 = WAL::new(&dir).unwrap();
+    let mut wal_1 = WAL::new(dir.path()).unwrap();
     for (i, e) in entries_1.iter().enumerate() {
       wal_1.set(e.0, e.1.unwrap(), i as u128).unwrap();
     }
@@ -350,13 +326,13 @@ mod tests {
       (b"Blueberry", Some(b"Blueberry Smoothie")),
       (b"Orange", Some(b"Orange Milkshake")),
     ];
-    let mut wal_2 = WAL::new(&dir).unwrap();
+    let mut wal_2 = WAL::new(dir.path()).unwrap();
     for (i, e) in entries_2.iter().enumerate() {
       wal_2.set(e.0, e.1.unwrap(), (i + 3) as u128).unwrap();
     }
     wal_2.flush().unwrap();
 
-    let (new_wal, new_mem_table) = WAL::load_from_dir(&dir).unwrap();
+    let (new_wal, new_mem_table) = WAL::load_from_dir(dir.path()).unwrap();
 
     let file = OpenOptions::new().read(true).open(&new_wal.path).unwrap();
     let mut reader = BufReader::new(file);
@@ -383,7 +359,5 @@ mod tests {
       assert_eq!(mem_e.value.as_ref().unwrap().as_slice(), e.1.unwrap());
       assert_eq!(mem_e.timestamp, (i + 3) as u128);
     }
-
-    remove_dir_all(&dir).unwrap();
   }
 }


### PR DESCRIPTION
This PR replaces the custom file/directory testing scaffolding with a well supported solution, `tempdir`, that simplifies and standardizes the file/directory scaffolding setup and cleanup.